### PR TITLE
Fixes fatal error.

### DIFF
--- a/src/muqsit/vanillagenerator/generator/ground/SnowyGroundGenerator.php
+++ b/src/muqsit/vanillagenerator/generator/ground/SnowyGroundGenerator.php
@@ -9,6 +9,7 @@ class SnowyGroundGenerator extends GroundGenerator{
 	/** @noinspection MagicMethodsValidityInspection */
 	/** @noinspection PhpMissingParentConstructorInspection */
 	public function __construct(){
+		$this->setGroundMaterial(self::$AIR);//fixes fatal error
 		$this->setTopMaterial(self::$SNOW);
 	}
 }


### PR DESCRIPTION
Fixes fatal error.

Tested.

Error stack trace:

Fatal error: Uncaught Error: Call to a member function getId() on null in D:\Dev\detreex-server\plugins\#Archinheim-master\src\muqsit\vanillagenerator\generator\ground\GroundGenerator.php:138
Stack trace:
#0 D:\Dev\detreex-server\plugins\#Archinheim-master\src\muqsit\vanillagenerator\generator\overworld\Normal.php(143): muqsit\vanillagenerator\generator\ground\GroundGenerator->generateTerrainColumn(Object(pocket
mine\level\SimpleChunkManager), Object(pocketmine\utils\Random), 0, 864, 140, -2.2105148196439)
#1 D:\Dev\detreex-server\plugins\#Archinheim-master\src\muqsit\vanillagenerator\generator\VanillaGenerator.php(111): muqsit\vanillagenerator\generator\overworld\Normal->generateChunkData(0, 54, Object(muqsit\va
nillagenerator\generator\VanillaBiomeGrid))
#2 D:\Dev\detreex-server\src\pocketmine\level\generator\GenerationTask.php(71): muqsit\vanillagenerator\generator\VanillaGenerator->generateChunk(0, 54)
#3 D:\Dev\detreex-server\src\pocketmine\scheduler\AsyncTask.php(43): pocketmine\level\generator\GenerationTask->onRun() in D:\Dev\detreex-server\plugins\#Archinheim-master\src\muqsit\vanillagenerator\generator\
ground\GroundGenerator.php on line 138
